### PR TITLE
bug report: init step is missing breaker training

### DIFF
--- a/src/run-round0.sh
+++ b/src/run-round0.sh
@@ -7,3 +7,10 @@ export PYTHONPATH=.
 python src/c001__train_fixer.py --round_name round0 --gpu_id 0 --max_epoch 2
 python src/c003__run_fixer.py   --round_name round0 --gpu_ids '0,1,2,3,4'
 python src/c005__eval_fixer.py  --round_name round0
+
+
+According to the paper, the initialization step contains the training of an initial fixer and a breaker as well. See the image in PR's description.
+However, in this script created for initialization step, you do not train the initial breaker. 
+The first breaker is trained in the first round.
+
+Is this a bug?


### PR DESCRIPTION
Hello,

I found a potential bug in your repo. 

According to the paper, the initialization step contains the training of an initial fixer and a breaker as well. See the image in PR's description.

![image](https://user-images.githubusercontent.com/77981442/217917802-e204ab6e-cc88-46bf-b705-1800a0a72059.png)

However, in the script created for the initialization step (`src/run-round0.sh`), you do not train the initial breaker. 
The first breaker is trained in the first round.
Is this a bug?

Thank you for your time and help!

Best,
Berkay Berabi